### PR TITLE
Use Sinatra's url method to generate URLs

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -9,10 +9,7 @@ require 'dm-migrations'
 require 'dm-validations'
 
 enable :sessions
-# set :url, (settings.environment == :production) ? "http://dbinbox.com/" : "http://127.0.0.1:9393/"
-# so hackey
 production = !File.exists?("../../projects")
-set :url, production ? "http://dbinbox.com/" : "http://127.0.0.1:9393/"
 
 directory = production ? File.expand_path("../../shared") : Dir.pwd
 DataMapper.setup(:default, "sqlite3://#{File.join(directory, "users.db")}")
@@ -140,7 +137,7 @@ post '/' do
   session[:username] = username
 
   # send them out to authenticate us
-  redirect dbsession.get_authorize_url(settings.url)
+  redirect dbsession.get_authorize_url(url('/'))
 end
 
 get "/js/app.js" do

--- a/views/index.haml
+++ b/views/index.haml
@@ -13,7 +13,7 @@
 -else
   %p{style: "color: green"} You're registered!
   %p
-    -url = settings.url + session[:username] if session[:username]
+    -url = url('/') + session[:username] if session[:username]
     %a{href: url}=url
 
 .row


### PR DESCRIPTION
By using `url('/')` instead of `set :url...`, we can avoid hard-coding the URL in the source.

I wanted this in dev so I didn't need to change the source if I accessed it through http://127.0.0.1, http://127.0.0.1.xip.io, or [http://localhost](http://localhost), or via a different port.
