### PR TITLE
Allow deleting dbinbox account

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -359,13 +359,8 @@ end
 
 post '/:username/delete' do
   # The user wants to delete their dbinbox account.
-  # First make sure they confirmed they want this.
+  # First check with Dropbox to make sure they own the account
 
-  if params[:delete_confirmation] != "DELETE"
-    redirect url("/#{params[:username]}/admin")
-  end
-
-  # Now check with Dropbox to make sure they own the account
   redirect_with_authenticated_dropboxsession(url("/#{params[:username]}/delete"))
 end
 

--- a/views/admin.haml
+++ b/views/admin.haml
@@ -25,4 +25,24 @@
       %input(type="checkbox" name="clear_access_code" id="clear_access_code")
   %input.btn.btn-primary(type="submit" value="Submit" style="float: right")
 
+
+
+%h1.span12
+  %img(class="modal-h-img sprite s_application_delete_32 modal-h-img" src="img/icon_spacer.gif")
+  Delete #{@user.display_name}'s dbinbox account
+
+%div{style: "margin-left: 20px; margin-bottom: 2em;"}
+  %p
+    Pressing the button below will unlink dbinbox from your Dropbox account.
+  %p
+    The URL <code>#{url(@user.username)}</code> will be available for anyone to register
+    with his or her Dropbox account.
+
+%form.form-horizontal.span12{action: "/#{@user.username}/delete", id: 'unlink_form', method: 'post'}
+  .control-group
+    %label.control-label(for="delete_confirmation") Type "DELETE"
+    .controls
+      %input(type="text" name="delete_confirmation" id="delete_confirmation")
+  %input.btn.btn-danger(type="submit" value="Delete account" style="float: right")
+
 .clearfix

--- a/views/admin.haml
+++ b/views/admin.haml
@@ -42,7 +42,7 @@
   .control-group
     %label.control-label(for="delete_confirmation") Type "DELETE"
     .controls
-      %input(type="text" name="delete_confirmation" id="delete_confirmation")
-  %input.btn.btn-danger(type="submit" value="Delete account" style="float: right")
+      %input(type="text" name="delete_confirmation" id="delete_confirmation" onkeyup="if($(this).val()=='DELETE'){$('#delete_button').removeAttr('disabled').removeClass('disabled');}")
+        %input#delete_button.btn.btn-danger.disabled(type="submit" value="Delete account" style="float: right" disabled="disabled")
 
 .clearfix


### PR DESCRIPTION
This allows the user to delete their own dbinbox account.
- Disable the "delete" button until the user types "DELETE" to confirm
- First verify the user owns the same Dropbox account
- As far as I can tell, the Dropbox API doesn't allow one to remove your app from the user's Dropbox account. However, removing our serialized session ensures we can't actually access their account anymore.
- The username is open for re-registration by anybody.
