### PR TITLE
Updated app.rb to allow for windows line endings

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -278,7 +278,7 @@ post '/:username/send_text' do
   message = params["message"]
   # add header to message
   # use @env['REMOTE_ADDR'] if request.ip doesn't work
-  message = "Uploaded #{Time.now.to_s} from #{request.ip}\n\n#{message}"
+  message = "Uploaded #{Time.now.to_s} from #{request.ip}\r\n\r\n#{message}"
 
   filename = Time.new.strftime("%Y-%m-%d-%H.%M.%S")
   filename += " " + params["filename"] if params["filename"] && !params["filename"].empty?


### PR DESCRIPTION
When sending a message via the web interface, the file will be formatted for unix-style line endings, which notepad.exe on Windows can't recognise.

Some might say this is a shortcoming of Notepad.exe, but since it was a simple fix, I did it anyway!

Fixes #29
